### PR TITLE
fix(bru): Replaced 'filter' with 'where'

### DIFF
--- a/bru/info.nu
+++ b/bru/info.nu
@@ -10,7 +10,7 @@ def info-cask [formula: string, extended?: bool] {
                 | update artifacts { |r|
                     (
                         $r.artifacts
-                            | filter { |x| ('app' in $x) or ('binary' in $x) or ('pkg' in $x) }
+                            | where { |x| ('app' in $x) or ('binary' in $x) or ('pkg' in $x) }
                             | each { |x|
                                 if ('app' in $x) {
                                     return ($x.app | first)

--- a/bru/list.nu
+++ b/bru/list.nu
@@ -17,7 +17,7 @@ export def main [--extended (-e)] {
     mut output = ($formulae
         | merge $casks
         | upsert type { |r| if 'token' in $r { 'cask' } else { 'formula' } }
-        | filter { |r| $r.installed != null }
+        | where { |r| $r.installed != null }
         | update installed { |r|
             if (($r.installed | describe) != 'string') {
                 $r.installed | first | get version


### PR DESCRIPTION
Nushell 0.105.x has deprecated 'filter' for 'where'. This patch makes that change and allows for nushell to startup without the deprecation warning